### PR TITLE
Fix wake lock not reacquiring after tab backgrounding

### DIFF
--- a/src/hooks/useWakeLock.ts
+++ b/src/hooks/useWakeLock.ts
@@ -20,6 +20,9 @@ export function useWakeLock(enabled: boolean) {
 					await lock.release();
 					return;
 				}
+				lock.addEventListener("release", () => {
+					if (sentinel === lock) sentinel = null;
+				});
 				sentinel = lock;
 			} catch {
 				// Wake lock can be denied (e.g. low battery, backgrounded tab);


### PR DESCRIPTION
## Summary
- The Wake Lock API auto-releases whenever the tab loses visibility (e.g. switching apps to check a notification), but the `sentinel` reference in `useWakeLock` was never cleared when that happened.
- On return to the tab, the `visibilitychange` handler saw a stale non-null `sentinel` and skipped re-requesting the lock, so the screen could sleep again for the rest of the session.
- Fix: listen for the sentinel's own `release` event and clear the reference there, so the next `visibilitychange` correctly re-acquires the lock.

## Test plan
- [x] `tsc --noEmit` passes
- [ ] Manual: start a session, background the tab (switch apps / check a notification), return, confirm the screen still stays awake

🤖 Generated with [Claude Code](https://claude.com/claude-code)