### PR TITLE
Bump version to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hero-tracker",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/hooks/useWakeLock.ts
+++ b/src/hooks/useWakeLock.ts
@@ -20,6 +20,9 @@ export function useWakeLock(enabled: boolean) {
 					await lock.release();
 					return;
 				}
+				lock.addEventListener("release", () => {
+					if (sentinel === lock) sentinel = null;
+				});
 				sentinel = lock;
 			} catch {
 				// Wake lock can be denied (e.g. low battery, backgrounded tab);


### PR DESCRIPTION
## Summary
- Patch bump for the wake lock re-acquisition fix merged in #82, which landed before this version bump was pushed.

## Test plan
- [ ] Verify `package.json` version reads 1.0.2 on master after merge